### PR TITLE
Scroll when codeblocks are wider than allocated space

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -72,6 +72,10 @@ code {
 	hyphens: none;
 }
 
+pre {
+	overflow: auto;
+}
+
 em {
 	font-style: normal;
 }

--- a/src/main.css
+++ b/src/main.css
@@ -72,7 +72,7 @@ code {
 	hyphens: none;
 }
 
-pre {
+pre[class*='language-'] {
 	overflow: auto;
 }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5474358/70826320-75b2a600-1d9b-11ea-90a8-39069efbf98f.png)

After:
![image](https://user-images.githubusercontent.com/5474358/70826287-63386c80-1d9b-11ea-9966-8ea35805ade3.png)