### PR TITLE
Fix property parsing

### DIFF
--- a/src/example/button/Button.tsx
+++ b/src/example/button/Button.tsx
@@ -3,12 +3,26 @@ import theme from '@dojo/framework/core/middleware/theme';
 
 import * as css from '../theme/default/button.m.css';
 
-export interface ButtonProperties {
+export interface Base {
+	/** A made up string property */
+	foo: string;
+	/** An optional method that does something and returns a string */
+	baseMethod?(): string;
+	baz: string;
+}
+
+export interface OtherBase {
+	/** An optional base property */
+	otherBaseProp?: string;
+	otherBaseMethod(): string;
+}
+
+type PickSome = Pick<Base, Exclude<keyof Base, 'foo'>>;
+export interface ButtonProperties extends PickSome, OtherBase {
 	label: string;
 }
 
 const factory = create({ theme }).properties<ButtonProperties>();
-
 export default factory(function Button({ properties, middleware: { theme } }) {
 	const { label } = properties();
 	const themedCss = theme.classes(css);


### PR DESCRIPTION
Fixes #26 by dealing with interface types directly. I arrived at this with some trial and error. It works for the test types I added to the example `Button` and seems to produce the same results when tested with dojo widgets as the current approach but I'm not positive there aren't scenarios where it would fail.