### PR TITLE
Covert cache to icache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -854,9 +854,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "7.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.6.tgz",
-      "integrity": "sha512-goDtruSAh/po8IBNGqxvzj0+/VQs+AcxxbLdEn/Nkn7VbtECk6MsHAJVdtAt5BKkquipWIoHNyqJFN1E98EOFQ==",
+      "version": "7.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.7.tgz",
+      "integrity": "sha512-ETXE8iy5snejhTvG40XwI63uXULofJjAdFi+U5jcTNaBxteuP1vP2Mv9+AzfCYIEhuTFwoxWqVq3TDLCid4sEw==",
       "dev": true,
       "requires": {
         "@types/cldrjs": "0.4.20",
@@ -1894,9 +1894,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.4.tgz",
-          "integrity": "sha512-Lue/mlp2egZJoHXZr4LndxDAd7i/7SQYhV0EjWfb/a4/OZ6tuVwMCVPiwkU5nsEipxEf7hmkSU7Em5VQ8P5NGA=="
+          "version": "13.1.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
+          "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
         }
       }
     },
@@ -2047,9 +2047,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.1.tgz",
-      "integrity": "sha512-n9fP8UrMxOi1wiM3oM+vMZHMJJ7WoQohqd63C20cmKOFkNEy9Q8hyZyDR6PWdvSYt3V3A7cwDq/kWxHlRYYZEg==",
+      "version": "4.41.2",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.2.tgz",
+      "integrity": "sha512-DNMQOfEvwzWRRyp6Wy9QVCgJ3gkelZsuBE2KUD318dg95s9DKGiT5CszmmV58hq8jk89I9NClre48AEy1MWAJA==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -3422,9 +3422,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001019",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz",
-          "integrity": "sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==",
+          "version": "1.0.30001020",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
+          "integrity": "sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA==",
           "dev": true
         }
       }
@@ -5793,9 +5793,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.327",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.327.tgz",
-      "integrity": "sha512-DNMd91VtKt44LIkFtpICxAWu/GSGFLUMDM/kFINJ3Oe47OimSnbMvO3ChkUCdUyit+pRdhdCcM3+i5bpli5gqg==",
+      "version": "1.3.329",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.329.tgz",
+      "integrity": "sha512-CoyYGbkQLwmOpaWRUZgeSNnEPH5fE5R8T7dhQIWV/rlIt+Kx6NFppQJ2oHELmzw8ZGabOBY5CrjGjyA+74QVoQ==",
       "dev": true
     },
     "elliptic": {
@@ -6132,9 +6132,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
       "dev": true
     },
     "eventsource-polyfill": {
@@ -8167,9 +8167,9 @@
       }
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.6.0.tgz",
+      "integrity": "sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -9188,13 +9188,12 @@
           }
         },
         "axios": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.1.tgz",
+          "integrity": "sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==",
           "dev": true,
           "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
+            "follow-redirects": "1.5.10"
           }
         },
         "body-parser": {
@@ -11580,9 +11579,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.44",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.44.tgz",
-      "integrity": "sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==",
+      "version": "1.1.45",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.45.tgz",
+      "integrity": "sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -15340,9 +15339,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
-      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -16623,9 +16622,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001019",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz",
-          "integrity": "sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==",
+          "version": "1.0.30001020",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
+          "integrity": "sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA==",
           "dev": true
         },
         "debug": {
@@ -17278,9 +17277,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001019",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz",
-          "integrity": "sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==",
+          "version": "1.0.30001020",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
+          "integrity": "sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA==",
           "dev": true
         },
         "cssesc": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "npm run package && dojo-release"
   },
   "peerDependencies": {
-    "@dojo/framework": "7.0.0-alpha.4",
+    "@dojo/framework": "7.0.0-alpha.7",
     "@dojo/themes": "^6.0.0"
   },
   "dependencies": {

--- a/src/ActiveLink.ts
+++ b/src/ActiveLink.ts
@@ -1,7 +1,7 @@
 import { create, diffProperty, invalidator, w } from '@dojo/framework/core/vdom';
 import { Handle } from '@dojo/framework/core/Destroyable';
 import injector from '@dojo/framework/core/middleware/injector';
-import cache from '@dojo/framework/core/middleware/cache';
+import icache from '@dojo/framework/core/middleware/icache';
 import { SupportedClassName } from '@dojo/framework/core/interfaces';
 import Link, { LinkProperties } from '@dojo/framework/routing/Link';
 import Router from '@dojo/framework/routing/Router';
@@ -19,12 +19,12 @@ function paramsEqual(linkParams: any = {}, contextParams: any = {}) {
 const factory = create({
 	injector,
 	diffProperty,
-	cache,
+	icache,
 	invalidator
 }).properties<ActiveLinkProperties>();
 
 export const ActiveLink = factory(function ActiveLink({
-	middleware: { diffProperty, injector, cache, invalidator },
+	middleware: { diffProperty, injector, icache, invalidator },
 	properties,
 	children
 }) {
@@ -34,7 +34,7 @@ export const ActiveLink = factory(function ActiveLink({
 	diffProperty('to', (current: ActiveLinkProperties, next: ActiveLinkProperties) => {
 		if (current.to !== next.to) {
 			const router = injector.get<Router>(routerKey);
-			const currentHandle = cache.get<Handle>('handle');
+			const currentHandle = icache.get<Handle>('handle');
 			if (currentHandle) {
 				currentHandle.destroy();
 			}
@@ -44,7 +44,7 @@ export const ActiveLink = factory(function ActiveLink({
 						invalidator();
 					}
 				});
-				cache.set('handle', handle);
+				icache.set('handle', handle, false);
 			}
 			invalidator();
 		}
@@ -52,13 +52,13 @@ export const ActiveLink = factory(function ActiveLink({
 
 	const router = injector.get<Router>(routerKey);
 	if (router) {
-		if (!cache.get('handle')) {
+		if (!icache.get('handle')) {
 			const handle = router.on('outlet', ({ outlet }) => {
 				if (outlet.id === to) {
 					invalidator();
 				}
 			});
-			cache.set('handle', handle);
+			icache.set('handle', handle, false);
 		}
 		const context = router.getOutlet(to);
 		const isActive = context && paramsEqual(matchParams, context.params);


### PR DESCRIPTION
Convert the existing cache usage to icache to remove the deprecation warnings.

Updates the framework dependency to current latest.