### PR TITLE
Removes unnecessary hr element when no examples are available

### DIFF
--- a/src/SideMenu.tsx
+++ b/src/SideMenu.tsx
@@ -47,27 +47,29 @@ export default factory(function SideBar({ properties, middleware: { theme } }) {
 						</li>
 					)}
 				</ul>
-				<hr classes="my-1 border-b-2 border-gray-200" />
-				<ul classes="mt-4 overflow-x-hidden">
-					{(config.widgets[widgetName].examples || []).map((example: any) => {
-						return (
-							<li classes="mb-2">
-								<ActiveLink
-									key={example.filename}
-									classes="block transition-fast hover:translate-r-2px hover:text-gray-900 text-gray-600 font-medium"
-									to="example"
-									params={{
-										widget: widgetName,
-										example: example.filename.toLowerCase()
-									}}
-									activeClasses={['font-bold']}
-								>
-									{example.filename.replace(/([A-Z])/g, ' $1').trim()}
-								</ActiveLink>
-							</li>
-						);
-					})}
-				</ul>
+				{config.widgets[widgetName].examples && <virtual>
+					<hr classes="my-1 border-b-2 border-gray-200" />
+					<ul classes="mt-4 overflow-x-hidden">
+						{(config.widgets[widgetName].examples || []).map((example: any) => {
+							return (
+								<li classes="mb-2">
+									<ActiveLink
+										key={example.filename}
+										classes="block transition-fast hover:translate-r-2px hover:text-gray-900 text-gray-600 font-medium"
+										to="example"
+										params={{
+											widget: widgetName,
+											example: example.filename.toLowerCase()
+										}}
+										activeClasses={['font-bold']}
+									>
+										{example.filename.replace(/([A-Z])/g, ' $1').trim()}
+									</ActiveLink>
+								</li>
+							);
+						})}
+					</ul>
+				</virtual>}
 				<hr classes="my-1 border-b-2 border-gray-200" />
 				<ul classes="mt-4 overflow-x-hidden">
 					<li classes="mb-2">


### PR DESCRIPTION
This PR prevents the `<hr>` element from rendering when no examples are available. This makes this section a little cleaner as it prevents a double render of `<hr>` and associated whitespace.

**Before**
![Screenshot_20200113_133029](https://user-images.githubusercontent.com/8822075/72259640-dfc3a280-3608-11ea-9392-45e20e4f7791.png)


**After**
![Screenshot_20200113_132923](https://user-images.githubusercontent.com/8822075/72259724-100b4100-3609-11ea-83b9-c65b2843fd59.png)

Resolves #36 