### PR TITLE
Add overflow-x: auto for code/pre to handle overflow

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -108,6 +108,7 @@ pre[class*='language-'] {
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
+	overflow-x: auto;
 }
 
 /* Inline code */


### PR DESCRIPTION
Resolves sample code overflowing the code/pre box:
![image](https://user-images.githubusercontent.com/1388138/72534930-aaf05f00-3845-11ea-983b-c6b16a0860c4.png)
