### PR TITLE
Stop stylesheets being able to be disabled by Intern

### DIFF
--- a/intern/reporter.js
+++ b/intern/reporter.js
@@ -105,3 +105,13 @@ tr.testResult.passed {
 }
 `;
 document.head.appendChild(style);
+for (var i = 0; i < document.styleSheets.length; i++) {
+	var stylesheet = document.styleSheets[i];
+	Object.defineProperty(stylesheet, 'disabled', {
+		get: function () {
+			return false;
+		},
+		set: function () {
+		}
+	});
+}


### PR DESCRIPTION
Cheeky hack to stop the html reporter from disabling stylesheets in later versions of Intern. This is not ideal, and we should write a custom html reporter in the future, but for now stops our custom styles from breaking.