### PR TITLE
Improve child parsing

### DIFF
--- a/src/Example.tsx
+++ b/src/Example.tsx
@@ -119,7 +119,7 @@ export default factory(function Example({
 				</div>
 			)}
 			{isOverview && widgetProperty && <InterfaceTable props={widgetProperty} />}
-			{isOverview && widgetChildren && (
+			{isOverview && widgetChildren && widgetChildren.length && (
 				<InterfaceTable props={widgetChildren} tableName="Children" />
 			)}
 			{isOverview && messages.length && <InterfaceTable props={messages} tableName="i18n Messages" descriptionLabel="Default" showTypes={false}/>}

--- a/src/example/InheritingButton/InheritingButton.tsx
+++ b/src/example/InheritingButton/InheritingButton.tsx
@@ -1,0 +1,16 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import theme from '@dojo/framework/core/middleware/theme';
+
+import * as css from '../theme/default/button.m.css';
+import { ButtonChildren } from '../NamedButton/NamedButton';
+import { ButtonProperties } from '../button/Button';
+
+const factory = create({ theme }).properties<ButtonProperties>().children<ButtonChildren>();
+export const InheritingButton = factory(function InheritingButton({ children, middleware: { theme } }) {
+	const [labelChild] = children();
+	const label = (labelChild && (labelChild as any).label) ? (labelChild as any).label : labelChild;
+	const themedCss = theme.classes(css);
+	return <button classes={[themedCss.root]}>{label}</button>;
+});
+
+export default InheritingButton;

--- a/src/example/InheritingButton/README.md
+++ b/src/example/InheritingButton/README.md
@@ -1,0 +1,3 @@
+# InheritingButton
+
+A functional widget that is both a named export and the default export.

--- a/src/example/InheritingButtonExample.tsx
+++ b/src/example/InheritingButtonExample.tsx
@@ -1,0 +1,8 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Button from './InheritingButton/InheritingButton';
+
+const factory = create();
+
+export default factory(function Basic() {
+	return <Button otherBaseMethod={() => ''} label="label" baz="foo">{{ label: 'Hello' }}</Button>;
+});

--- a/src/example/NamedButton/NamedButton.tsx
+++ b/src/example/NamedButton/NamedButton.tsx
@@ -4,14 +4,20 @@ import i18n from '@dojo/framework/core/middleware/i18n';
 import bundle from './nls/NamedButton';
 
 import * as css from '../theme/default/button.m.css';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 
-export interface ButtonProperties {
-	label: string;
+export interface ButtonChildren {
+	label?: RenderResult;
 }
 
-const factory = create({ theme, i18n }).properties<ButtonProperties>();
-export const NamedButton = factory(function NamedButton({ properties, middleware: { theme, i18n } }) {
-	const { label } = properties();
+export interface FunctionChild {
+	(foo: string): RenderResult;
+}
+
+const factory = create({ theme, i18n }).children<ButtonChildren | RenderResult | FunctionChild>();
+export const NamedButton = factory(function NamedButton({ properties, children, middleware: { theme, i18n } }) {
+	const [labelChild] = children();
+	const label = (labelChild && (labelChild as any).label) ? (labelChild as any).label : labelChild;
 	const { messages } = i18n.localize(bundle);
 	const themedCss = theme.classes(css);
 	return <button classes={[themedCss.root]}>{`${label} - ${messages.message}`}</button>;

--- a/src/example/NamedButtonExample.tsx
+++ b/src/example/NamedButtonExample.tsx
@@ -4,5 +4,5 @@ import Button from './NamedButton/NamedButton';
 const factory = create();
 
 export default factory(function Basic() {
-	return <Button label="Hello" />;
+	return <Button>Hello</Button>;
 });

--- a/src/example/config.ts
+++ b/src/example/config.ts
@@ -7,6 +7,7 @@ import NamedClassButtonExample from './NamedClassButtonExample';
 
 import red from './theme/red';
 import blue from './theme/blue';
+import InheritingButtonExample from './InheritingButtonExample';
 
 export default {
 	name: '@dojo/widgets',
@@ -75,6 +76,15 @@ export default {
 				example: {
 					filename: 'NamedClassButtonExample',
 					module: NamedClassButtonExample
+				}
+			}
+		},
+		InheritingButton: {
+			filename: 'InheritingButton',
+			overview: {
+				example: {
+					filename: 'InheritingButtonExample',
+					module: InheritingButtonExample
 				}
 			}
 		}

--- a/src/interfaces.block.ts
+++ b/src/interfaces.block.ts
@@ -246,7 +246,7 @@ export default function(config: { [index: string]: string }) {
 
 		if (unionTypes && unionTypes.length) {
 			unionTypes.forEach((unionType) => {
-				const unionProperties = getWidgetProperties(unionType);
+				const unionProperties = getPropertyDetails(unionType);
 				unionProperties.forEach(type => parseUnionType(type, properties));
 			});
 		}
@@ -269,7 +269,7 @@ export default function(config: { [index: string]: string }) {
 						optional: false
 					});
 				});
-				const unionProperties = getWidgetProperties(unionType);
+				const unionProperties = getPropertyDetails(unionType);
 				unionProperties.forEach(type => parseUnionType(type, children));
 			}
 		});


### PR DESCRIPTION
This attempts to improve the parsing of the `children` type of widgets by:
* Applying the same logic as for properties so that if this is a factory we simply look at the actual type parameter instead of searching the file based on a naming convention
* Dealing with child types that are not property bags

The first will resolve #64 but will not fix the child type documentation for widgets like `BreadcrumbGroup` that have a function signature as their only child, and will result in displaying all the properties of an array as children for widgets that accept a `RenderResult`. The second change fixes those problems but I'm not sure how we want to display that info. Our current layout isn't set up for this kind of interface. 

This is what I have as a placeholder. Note that the individual display of `string`, `false`, `VNode`, etc. is caused by TypeScript now inlining union types. I don't know that there's anything to be done about that short of hardcoded logic for detecting those and showing `RenderResult` instead.
![image](https://user-images.githubusercontent.com/5474358/85634531-6ce73a80-b630-11ea-93d6-4e8d1fead306.png)
