### PR TITLE
Deal with undefined `widgetProperty` in example

### DIFF
--- a/src/Example.tsx
+++ b/src/Example.tsx
@@ -70,7 +70,7 @@ export default factory(function Example({
 
 	const widgetReadme = widgetReadmes[readmePath];
 	const widgetExample = widgetExamples[examplePath];
-	const { properties: widgetProperty, children: widgetChildren } = widgetProperties[widgetName];
+	const { properties: widgetProperty, children: widgetChildren } = widgetProperties[widgetName] || {} as any;
 	const widgetTheme = widgetThemes[widgetName];
 
 	const dimensions = postMessage();
@@ -118,7 +118,7 @@ export default factory(function Example({
 					</a>
 				</div>
 			)}
-			{isOverview && <InterfaceTable props={widgetProperty} />}
+			{isOverview && widgetProperty && <InterfaceTable props={widgetProperty} />}
 			{isOverview && widgetChildren && (
 				<InterfaceTable props={widgetChildren} tableName="Children" />
 			)}


### PR DESCRIPTION
The issue in #68 was that the `widgetProperties` can be an empty object and `Example` assumed the value at a key would be an object.
Resolves #68
