### PR TITLE
feat: page titles and example controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2299,6 +2299,11 @@
         }
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz",
+      "integrity": "sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w=="
+    },
     "@fullhuman/postcss-purgecss": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@dojo/framework": "~7.0.0"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.3",
     "canonical-path": "1.0.0",
     "cldr-data": "36.0.0",
     "postcss": "7.0.21",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@dojo/framework": "~7.0.0"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.3",
+    "@fortawesome/fontawesome-free": "5.15.3",
     "canonical-path": "1.0.0",
     "cldr-data": "36.0.0",
     "postcss": "7.0.21",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ import getWidgetProperties from './interfaces.block';
 import getTheme from './theme.block';
 import code from './code.block';
 
+import '@fortawesome/fontawesome-free/css/all.css';
+
 function getWidgetFileNames(config: any): { [index: string]: string } {
 	return Object.keys(config.widgets).reduce((newConfig, widget) => {
 		return {

--- a/src/Example.tsx
+++ b/src/Example.tsx
@@ -85,31 +85,68 @@ export default factory(function Example({
 		dimensions.height = '600px';
 	}
 
+	const isFullscreen = icache.get('isFullscreen');
+	const isCodeShowing = icache.getOrSet('isCodeShowing', true);
+
 	return (
 		<div>
 			{isOverview && <div innerHTML={widgetReadme} />}
 			{isOverview && <HorizontalRule />}
 			<h2 classes="text-2xl h mb-4">{example.title || 'Example'}</h2>
-			<div classes="bg-white rounded-t-lg overflow-hidden border-b-0 border-t border-l border-r border-gray-400 p-4">
-				{example.sandbox ? (
-					<iframe
-						src={`?cacheBust=${widgetName}-${
-							example.filename
-						}-${themeName}#widget/${widgetName}/sandbox/${example.filename.toLowerCase()}?theme=${themeName}`}
-						classes="w-full iframe"
-						styles={dimensions}
-					/>
-				) : (
-					<div key="example-container" styles={example.size ? dimensions : {}}>
-						<example.module />
-					</div>
-				)}
+			<div
+				classes={`bg-white overflow-hidden border-t border-l border-r border-gray-400 ${
+					!isCodeShowing ? 'border-b' : 'border-b-0'
+				} ${isFullscreen ? 'fixed top-0 left-0 w-screen h-screen z-50' : 'rounded-t-lg'}`}
+			>
+				<div
+					classes={`border border-gray-400 border-t-0 border-l-0 border-r-0 flex justify-end ${
+						isFullscreen ? 'p-6' : 'px-4 py-2'
+					}`}
+				>
+					<button
+						classes={`border-0 appearance-none bg-transparent cursor-pointer p-0 ${
+							isFullscreen ? 'text-black mr-6' : 'text-gray-500 mr-4'
+						}`}
+						onclick={() => icache.set('isFullscreen', !isFullscreen)}
+					>
+						{isFullscreen ? (
+							<i class="fas fa-compress-alt"></i>
+						) : (
+							<i class="fas fa-expand-alt"></i>
+						)}
+					</button>
+					<button
+						classes={`border-0 appearance-none bg-transparent cursor-pointer p-0 ${
+							isCodeShowing ? 'text-black' : 'text-gray-500'
+						}`}
+						onclick={() => icache.set('isCodeShowing', !isCodeShowing)}
+					>
+						<i class="fas fa-code"></i>
+					</button>
+				</div>
+				<div classes="p-4">
+					{example.sandbox ? (
+						<iframe
+							src={`?cacheBust=${widgetName}-${
+								example.filename
+							}-${themeName}#widget/${widgetName}/sandbox/${example.filename.toLowerCase()}?theme=${themeName}`}
+							classes="w-full iframe"
+							styles={dimensions}
+						/>
+					) : (
+						<div key="example-container" styles={example.size ? dimensions : {}}>
+							<example.module />
+						</div>
+					)}
+				</div>
 			</div>
-			<div classes="rounded-b-lg bg-gray-800">
-				<pre classes="bg-blue-900 language-ts rounded px-4 py-4">
-					<code classes="language-ts" innerHTML={widgetExample} />
-				</pre>
-			</div>
+			{isCodeShowing && (
+				<div classes="rounded-b-lg bg-gray-800">
+					<pre classes="bg-blue-900 language-ts rounded px-4 py-4">
+						<code classes="language-ts" innerHTML={widgetExample} />
+					</pre>
+				</div>
+			)}
 			{codesandboxPath && (
 				<div classes="my-4">
 					<a href={codesandboxPath}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,12 @@ export default ({ config }: { config: Config }) => {
 		const theme = getThemeFromConfig(config);
 		const registry = new Registry();
 		registerThemeInjector(theme.theme, registry);
-		registerRouterInjector(routes, registry);
+		registerRouterInjector(routes, registry, {
+			setDocumentTitle: ({ params, title }) => {
+				const section = params.widget || title;
+				return `Parade${section ? ` - ${section}` : ''}`;
+			}
+		});
 
 		const r = renderer(() => <App config={config} />);
 		r.mount({ registry, domNode: document.getElementById('app')!, transition });

--- a/src/main.css
+++ b/src/main.css
@@ -149,10 +149,6 @@ h1 {
 	}
 }
 
-.z-100 {
-	z-index: 1000 !important;
-}
-
 .max-w-screen-xl {
 	max-width: 1280px !important;
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,7 +3,8 @@ export default [
 		id: 'landing',
 		outlet: 'main',
 		path: '/',
-		defaultRoute: true
+		defaultRoute: true,
+		title: 'Home'
 	},
 	{
 		id: 'widget',


### PR DESCRIPTION
This pull request updates Parade to set page titles using the routing injector, to support collapsible code panes, and to support full screen examples for easier development.

**Note:** I think the visuals of all of this (including the example toolbar) are secondary at this point, especially if we can get minimal design input for a fresh look and feel.

Resolves #76
Resolves #79 
Resolves #82 

**Preview**

![preview](https://i.gyazo.com/31a561cc04a2dec8ba0b2c35a6803c50.gif)