### PR TITLE
feat: support widget description content

### DIFF
--- a/src/Example.tsx
+++ b/src/Example.tsx
@@ -88,6 +88,12 @@ export default factory(function Example({
 	const isFullscreen = icache.get('isFullscreen');
 	const isCodeShowing = icache.getOrSet('isCodeShowing', true);
 
+	let description;
+	if (example.description) {
+		description =
+			typeof example.description === 'string' ? example.description : <example.description />;
+	}
+
 	return (
 		<div>
 			{isOverview && <div innerHTML={widgetReadme} />}
@@ -156,6 +162,13 @@ export default factory(function Example({
 						/>
 					</a>
 				</div>
+			)}
+			{description && (
+				<virtual>
+					<HorizontalRule />
+					<h2 classes="text-2xl mb-4">Description</h2>
+					{description}
+				</virtual>
 			)}
 			{isOverview && widgetProperty && <InterfaceTable props={widgetProperty} />}
 			{isOverview && widgetChildren && widgetChildren.length && (

--- a/src/example/config.ts
+++ b/src/example/config.ts
@@ -8,6 +8,11 @@ import NamedClassButtonExample from './NamedClassButtonExample';
 import red from './theme/red';
 import blue from './theme/blue';
 import InheritingButtonExample from './InheritingButtonExample';
+import { create } from '@dojo/framework/core/vdom';
+
+const ExampleDescription = create()(
+	() => 'This is an example of an optional description that is a widget.'
+);
 
 export default {
 	name: '@dojo/widgets',
@@ -30,7 +35,8 @@ export default {
 			overview: {
 				example: {
 					filename: 'ButtonExample',
-					module: ButtonExample
+					module: ButtonExample,
+					description: 'This is an example of an optional description that is a string.'
 				}
 			},
 			examples: [
@@ -75,7 +81,8 @@ export default {
 			overview: {
 				example: {
 					filename: 'NamedClassButtonExample',
-					module: NamedClassButtonExample
+					module: NamedClassButtonExample,
+					description: ExampleDescription
 				}
 			}
 		},


### PR DESCRIPTION
This pull request adds support for configuration-driven widget descriptions that can be either strings inline in the config or references to a widget module.

Resolves #73 

**Preview**

<img width="1405" alt="Screen Shot 2021-05-21 at 10 13 18 AM" src="https://user-images.githubusercontent.com/334586/119151448-64081000-ba1d-11eb-88c8-3636b4b93442.png">

<img width="1405" alt="Screen Shot 2021-05-21 at 10 13 26 AM" src="https://user-images.githubusercontent.com/334586/119151463-68342d80-ba1d-11eb-97c5-ee1f33758dd1.png">

